### PR TITLE
add note about kubelet errors to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This example deploys Datadog's [Docker agent](https://docs.datadoghq.com/agent/d
 The URL will look like `datadog-agent-lkyz` with APM available on TCP port `8126` and DogStatsD on UDP port `8125`.
 
 > You will need to configure your Datadog API key by setting the `DD_API_KEY` environment variable to your private service.
+
+Errors of the form `"Unable to detect the kubelet URL automatically: impossible to reach Kubelet with host:` may be safely ignored. The kubelet is part of the Render control-plane and inaccessible to user workloads. The DataDog Agent will still be able to capture and send metrics.

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ The URL will look like `datadog-agent-lkyz` with APM available on TCP port `8126
 
 > You will need to configure your Datadog API key by setting the `DD_API_KEY` environment variable to your private service.
 
-Errors of the form `"Unable to detect the kubelet URL automatically: impossible to reach Kubelet with host:` may be safely ignored. The kubelet is part of the Render control-plane and inaccessible to user workloads. The DataDog Agent will still be able to capture and send metrics.
+Errors of the form `"Unable to detect the kubelet URL automatically: impossible to reach Kubelet with host:` can be safely ignored. The kubelet is part of the Render control plane and inaccessible to user workloads. The DataDog Agent will still be able to capture and send metrics from your applications.


### PR DESCRIPTION
Errors from the Agent being unable to connect to the kubelet may be safely ignored. The kubelet is part of the Render control plane and is inaccessible to user workloads. Additional context can be found in this community slack thread: https://render-community.slack.com/archives/CH85FC7PY/p1620410961199600