### PR TITLE
Remove kubelet logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM datadog/agent:7
 
-# disable all Kubernetes checks (they don't work on Render)
-RUN rm -rf /etc/datadog-agent/conf.d/kube*
+# disable autoconfigured checks; DD container checks
+# do not work as-is on Render since there's no access
+# to Kubelet/kube-state-metrics.
+ENV DD_AUTOCONFIG_FROM_ENVIRONMENT=false
 
 ENV NON_LOCAL_TRAFFIC=true
 ENV DD_LOGS_STDOUT=yes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM datadog/agent:7
 
+# disable all Kubernetes checks (they don't work on Render)
+RUN rm -rf /etc/datadog-agent/conf.d/kube*
+
 ENV NON_LOCAL_TRAFFIC=true
 ENV DD_LOGS_STDOUT=yes
 

--- a/README.md
+++ b/README.md
@@ -9,5 +9,3 @@ This example deploys Datadog's [Docker agent](https://docs.datadoghq.com/agent/d
 The URL will look like `datadog-agent-lkyz` with APM available on TCP port `8126` and DogStatsD on UDP port `8125`.
 
 > You will need to configure your Datadog API key by setting the `DD_API_KEY` environment variable to your private service.
-
-Errors of the form `"Unable to detect the kubelet URL automatically: impossible to reach Kubelet with host:` can be safely ignored. The kubelet is part of the Render control plane and inaccessible to user workloads. The DataDog Agent will still be able to capture and send metrics from your applications.


### PR DESCRIPTION
Disable autoconfigured checks; DD container checks do not work as-is on Render since there's no access to Kubelet/kube-state-metrics.